### PR TITLE
Configure Nova to work with ceph.client.nova

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,7 +219,7 @@ Nova with ephemeral configured with Ceph
           rbd_pool: nova
           rbd_user: nova
           secret_uuid: 03006edd-d957-40a3-ac4c-26cd254b3731
-          client_cinder_key: AQAqvDZYV7wxOxAAllhrG3lbL9wggjgUHKJ3MQ==
+          client_nova_key: AQAqvDZYV7wxOxAAllhrG3lbL9wggjgUHKJ3MQ==
           cluster: ${_param:ceph_cluster}
           ceph_host: ${_param:ceph_backend_mon_host}
           ceph_port: ${_param:ceph_backend_mon_port}

--- a/nova/compute.sls
+++ b/nova/compute.sls
@@ -142,16 +142,16 @@ ceph_virsh_secret_define:
 
 ceph_virsh_secret_set_value:
   cmd.run:
-  - name: "virsh secret-set-value --secret {{ compute.ceph.secret_uuid }} --base64 {{ compute.ceph.client_cinder_key }} "
-  - unless: "virsh secret-get-value {{ compute.ceph.secret_uuid }} | grep {{ compute.ceph.client_cinder_key }}"
+  - name: "virsh secret-set-value --secret {{ compute.ceph.secret_uuid }} --base64 {{ compute.ceph.client_nova_key }} "
+  - unless: "virsh secret-get-value {{ compute.ceph.secret_uuid }} | grep {{ compute.ceph.client_nova_key }}"
   - require:
     - cmd: ceph_virsh_secret_define
 
 {% set ceph_backend_mon_host = pillar['nova']['compute']['ceph']['ceph_host'] %}
 {% set ceph_backend_mon_port = pillar['nova']['compute']['ceph']['ceph_port'] %}
 {% set ceph_cluster = pillar['nova']['compute']['ceph']['cluster'] %}
-{% set ceph_user = 'nova' %}
-{% set ceph_key = pillar['nova']['compute']['ceph']['client_cinder_key'] %}
+{% set ceph_user = pillar['nova']['compute']['ceph']['rbd_user'] %}
+{% set ceph_key = pillar['nova']['compute']['ceph']['client_nova_key'] %}
 {% include "ceph_backend/init.sls" %}
 
 {% endif %}

--- a/nova/files/secret.xml
+++ b/nova/files/secret.xml
@@ -2,6 +2,6 @@
 <secret ephemeral='no' private='no'>
   <uuid>{{ compute.ceph.secret_uuid }}</uuid>
   <usage type='ceph'>
-    <name>client.{{ compute.ceph.get('rbd_user', 'cinder') }} secret</name>
+    <name>client.{{ compute.ceph.get('rbd_user', 'nova') }} secret</name>
   </usage>
 </secret>


### PR DESCRIPTION
Eliminated hardcode in nova/compute.sls 
Renamed client_cinder_key into client_nova_key